### PR TITLE
Add Ctrl-u and Ctrl-d bindings for PageUp and PageDown

### DIFF
--- a/docs/usage.html
+++ b/docs/usage.html
@@ -182,6 +182,14 @@
       </li>
       <li>
         <i>count</i>
+        <code>Ctrl-d</code> Move down by one window's half height or <code>N</code> windows' half heights.
+      </li>
+      <li>
+        <i>count</i>
+        <code>Ctrl-u</code> Move up by one window's half height or <code>N</code> windows' half heights.
+      </li>
+      <li>
+        <i>count</i>
         <code>0</code>, <code>^</code> Move to the first sibling of the focused node's parent.
       </li>
       <li>

--- a/src/app.rs
+++ b/src/app.rs
@@ -148,11 +148,11 @@ impl App {
                         }
                         Key::Ctrl('u') => {
                             let count = self.parse_input_buffer_as_number();
-                            Some(Action::PageUp(count))
+                            Some(Action::HalfPageUp(count))
                         }
                         Key::Ctrl('d') => {
                             let count = self.parse_input_buffer_as_number();
-                            Some(Action::PageDown(count))
+                            Some(Action::HalfPageDown(count))
                         }
                         Key::Char('K') => {
                             let lines = self.parse_input_buffer_as_number();

--- a/src/app.rs
+++ b/src/app.rs
@@ -146,6 +146,14 @@ impl App {
                             let count = self.parse_input_buffer_as_number();
                             Some(Action::PageDown(count))
                         }
+                        Key::Ctrl('u') => {
+                            let count = self.parse_input_buffer_as_number();
+                            Some(Action::PageUp(count))
+                        }
+                        Key::Ctrl('d') => {
+                            let count = self.parse_input_buffer_as_number();
+                            Some(Action::PageDown(count))
+                        }
                         Key::Char('K') => {
                             let lines = self.parse_input_buffer_as_number();
                             Some(Action::FocusPrevSibling(lines))

--- a/src/jless.help
+++ b/src/jless.help
@@ -40,6 +40,9 @@
   PageDown  *  Move down by one window (or [4mN[0m windows).
   PageUp    *  Move up   by one window (or [4mN[0m windows).
 
+  ^d        *  Move down by one half window (or [4mN[0m half windows).
+  ^u        *  Move up   by one half window (or [4mN[0m half windows).
+
   0  ^         Move to the first sibling of the focused node's parent.
   $            Move to the last  sibling of the focused node's parent.
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -92,6 +92,8 @@ pub enum Action {
 
     ScrollUp(usize),
     ScrollDown(usize),
+    HalfPageUp(usize),
+    HalfPageDown(usize),
     PageUp(usize),
     PageDown(usize),
 
@@ -134,6 +136,8 @@ impl JsonViewer {
             Action::FocusMatchingPair => self.focus_matching_pair(),
             Action::ScrollUp(n) => self.scroll_up(n),
             Action::ScrollDown(n) => self.scroll_down(n),
+            Action::HalfPageUp(n) => self.scroll_up((self.dimensions.height / 2) as usize * n),
+            Action::HalfPageDown(n) => self.scroll_down((self.dimensions.height / 2) as usize * n),
             Action::PageUp(n) => self.scroll_up(self.dimensions.height as usize * n),
             Action::PageDown(n) => self.scroll_down(self.dimensions.height as usize * n),
             Action::MoveFocusedLineToTop => self.move_focused_line_to_top(),
@@ -179,6 +183,8 @@ impl JsonViewer {
             Action::FocusMatchingPair => true,
             Action::ScrollUp(_) => false,
             Action::ScrollDown(_) => false,
+            Action::HalfPageUp(_) => false,
+            Action::HalfPageDown(_) => false,
             Action::PageUp(_) => false,
             Action::PageDown(_) => false,
             Action::MoveFocusedLineToTop => false,
@@ -201,6 +207,8 @@ impl JsonViewer {
                 | Action::FocusNextSibling(_)
                 | Action::ScrollUp(_)
                 | Action::ScrollDown(_)
+                | Action::HalfPageUp(_)
+                | Action::HalfPageDown(_)
                 | Action::PageUp(_)
                 | Action::PageDown(_)
                 | Action::MoveFocusedLineToTop


### PR DESCRIPTION
Just tried out jless and the first thing I noticed was that I couldn't jump pages with `Ctrl-d` and `Ctrl-u`.