### PR TITLE
Feature: Display path of item under cursor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -122,6 +122,13 @@ impl App {
                             let lines = self.parse_input_buffer_as_number();
                             Some(Action::MoveUp(lines))
                         }
+                        Key::Char('p') => {
+                            self.message = Some((
+                                    format!("Path: \"{}\"", self.viewer.path()),
+                                    MessageSeverity::Info
+                            ));
+                            None
+                        }
                         Key::Down
                         | Key::Char('j')
                         | Key::Char(' ')

--- a/src/jless.help
+++ b/src/jless.help
@@ -11,6 +11,8 @@
 
   F1 :help         Show this help screen.
 
+  p                Display the path of the item under the cursor.
+
                                     [1mMOVING[0m
 
   j  DownArrow  *  Move focus down one line (or [4mN[0m lines).

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -50,6 +50,28 @@ impl JsonViewer {
             mode,
         }
     }
+    pub fn path(&self) -> String {
+        let mut p = String::new();
+        let mut row = &self.flatjson[self.focused_row];
+        loop {
+            let label = if let Some(ref k) = row.key_range {
+                self.flatjson.1[k.start+1..k.end-1].to_string()
+            } else {
+                row.index.to_string()
+            };
+            if let OptionIndex::Index(i) = row.parent {
+                row = &self.flatjson[i];
+                p = format!("{}.{}", label, p);
+            } else {
+                break;
+            }
+        }
+        if p.len() > 0 {
+            p[..p.len()-1].to_string()
+        } else {
+            String::new()
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Implement Feature from issue https://github.com/PaulJuliusMartinez/jless/issues/10
Press `p` to display the path of the item under the cursor.