### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643119265,
+        "narHash": "sha256-mmDEctIkHSWcC/HRpeaw6QOe+DbNOSzc0wsXAHOZWwo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+# Nix flake for jless. This means that where Nix is installed (see
+# https://nixos.org/explore.html), jless can be run immediately via
+#
+#   nix run github:PaulJuliusMartinez/jless
+#
+# or with arguments like this:
+#
+#   nix run github:PaulJuliusMartinez/jless -- --help
+#
+# and is easy to include in a machine or user environment via the overlay.
+{
+  description = "A command-line pager for JSON data";
+
+  inputs.utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, utils }:
+    let
+      # Get metadata from Cargo.toml
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+      name = cargoToml.package.name;
+
+      # How to build
+      build = { rustPlatform }: rustPlatform.buildRustPackage
+        {
+          pname = name;
+          version = cargoToml.package.version;
+          src = ./.;
+          cargoLock = { lockFile = ./Cargo.lock; };
+          doCheck = true;
+        };
+
+      # Create overlay that includes this package
+      overlay = final: prev: {
+        ${name} = final.callPackage build { };
+      };
+      overlays = [ overlay ];
+    in
+
+    # Finally, define the flake outputs
+    { inherit overlay overlays; } //
+    (utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system overlays; };
+      in
+      rec {
+        # nix build
+        packages.${name} = pkgs.${name};
+        defaultPackage = packages.${name};
+
+        # nix develop
+        devShell = pkgs.mkShell {
+          inputsFrom = [ defaultPackage ];
+          buildInputs = with pkgs; [ rustc rust-analyzer clippy rustfmt ];
+        };
+      }));
+}


### PR DESCRIPTION
I'm not sure if you'll want this or not (absolutely no problem if not!) but offering it in case.

The [Nix package manager](https://nixos.org) runs on Linux and macOS, often in addition to the system package manager. One of its features ("flakes") enables people to use packages even when not managed by the central package repo. With this addition, for example, someone can try out jless simply by running
```
nix run github:PaulJuliusMartinez/jless
```
(which if not already cached, downloads and builds the executable). More usefully, the "overlay" in `flake.nix` makes it easy to incorporate jless into a nix-managed reproducible+declarative environment (whether that's just a user environment, or an entire linux system).

These two files here don't have to change with the usual release cycle (eg they pick up the name/version from `Cargo.toml`). So they shouldn't be a maintenance burden, just additive.