### PR TITLE
Use freopen to move /dev/tty input to stdin so rustyline works when piping in input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ New features / changes:
   node, rather than moving down a line. (Functionality was previous
   available via `i`, but was undocumented; `i` has become unmapped.)
 
+Bug Fixes:
+- [Issue #7 / PR #32]: Fix issue with rustyline always reading from
+  STDIN preventing `/` command from working when input provided via
+  STDIN.
+
 Internal:
 - [PR #17]: Upgrade from structopt to clap v3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "isatty",
  "lazy_static",
  "libc",
+ "libc-stdhandle",
  "logos",
  "regex",
  "rustyline",
@@ -235,6 +236,16 @@ name = "libc"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+
+[[package]]
+name = "libc-stdhandle"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dac2473dc28934c5e0b82250dab231c9d3b94160d91fe9ff483323b05797551"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ signal-hook = "0.3.8"
 libc = "0.2"
 clap = { version = "3.0", features = ["derive"] }
 isatty = "0.1"
+libc-stdhandle = "0.1.0"

--- a/src/input.rs
+++ b/src/input.rs
@@ -14,7 +14,18 @@ const BUFFER_SIZE: usize = 1024;
 const ESCAPE: u8 = 0o33;
 
 pub fn get_input() -> impl Iterator<Item = io::Result<TuiEvent>> {
+    // The readline library we use, rustyline, always gets its input from STDIN.
+    // If jless accepts its input from STDIN, then rustyline can't accept input.
+    // To fix this, we open up /dev/tty, and remap it to STDIN, as suggested in
+    // this StackOverflow post:
+    //
+    // https://stackoverflow.com/questions/29689034/piped-stdin-and-keyboard-same-time-in-c
+    //
+    // rustyline may add its own fix to support reading from /dev/tty:
+    //
+    // https://github.com/kkawakam/rustyline/issues/599
     unsafe {
+        // freopen(3) docs: https://linux.die.net/man/3/freopen
         let filename = std::ffi::CString::new("/dev/tty").unwrap();
         let path = std::ffi::CString::new("r").unwrap();
         let _ = libc::freopen(filename.as_ptr(), path.as_ptr(), libc_stdhandle::stdin());

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::collapsible_else_if)]
 
 extern crate lazy_static;
+extern crate libc_stdhandle;
 
 use std::fs::File;
 use std::io;
@@ -52,6 +53,8 @@ fn main() {
     let stdout = MouseTerminal::from(HideCursor::from(AlternateScreen::from(
         io::stdout().into_raw_mode().unwrap(),
     )));
+    let input = Box::new(input::get_input());
+
     let mut app = match App::new(&opt, json_string, input_filename, Box::new(stdout)) {
         Ok(jl) => jl,
         Err(err) => {
@@ -60,7 +63,7 @@ fn main() {
         }
     };
 
-    app.run(Box::new(input::get_input()));
+    app.run(input);
 }
 
 fn print_pretty_printed_json(json: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,15 @@ fn main() {
         std::process::exit(0);
     }
 
+    // Create our input *before* constructing the App. When we get the input,
+    // we use freopen to remap /dev/tty to STDIN so that rustyline works when
+    // JSON input is provided via STDIN. rustyline gets initialized when we
+    // create the App, so by putting this before, we make sure rustyline gets
+    // the /dev/tty input.
+    let input = Box::new(input::get_input());
     let stdout = MouseTerminal::from(HideCursor::from(AlternateScreen::from(
         io::stdout().into_raw_mode().unwrap(),
     )));
-    let input = Box::new(input::get_input());
 
     let mut app = match App::new(&opt, json_string, input_filename, Box::new(stdout)) {
         Ok(jl) => jl,


### PR DESCRIPTION
Resolves https://github.com/PaulJuliusMartinez/jless/issues/7.

Might clean this up a bit, or figure out how to get rid of the tiny, four-year old, 2-commit, unmaintained dependency.


I should also add better error-handling when initializing the editor so it doesn't crash the program.