### PR TITLE
Change Space command to toggle collapsed state of focused node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ latest
 New features / changes:
 - [PR #42]: Space now toggles the collapsed state of the currently focused
   node, rather than moving down a line. (Functionality was previous
-  available via `i`, but was undocumnted; `i` has become unmapped.)
+  available via `i`, but was undocumented; `i` has become unmapped.)
 
 Internal:
 - [PR #17]: Upgrade from structopt to clap v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ latest
 ==================
 
 New features:
-- Space now toggles the collapsed state of the currently focused node,
-  rather than moving down a line.
+- [PR #42]: Space now toggles the collapsed state of the currently focused
+  node, rather than moving down a line. (Functionality was previous
+  available via `i`, but was undocumnted; `i` has become unmapped.)
 
 Internal:
 - [PR #17]: Upgrade from structopt to clap v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 latest
 ==================
 
-New features:
+New features / changes:
 - [PR #42]: Space now toggles the collapsed state of the currently focused
   node, rather than moving down a line. (Functionality was previous
   available via `i`, but was undocumnted; `i` has become unmapped.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 latest
 ==================
 
+New features:
+- Space now toggles the collapsed state of the currently focused node,
+  rather than moving down a line.
+
 Internal:
 - [PR #17]: Upgrade from structopt to clap v3
 

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -135,8 +135,7 @@
         <code>j</code>,
         <code>DownArrow</code>,
         <code>Ctrl-n</code>,
-        <code>Enter</code>,
-        <code>Space</code> Move focus down one line (or <code>N</code> lines).
+        <code>Enter</code> Move focus down one line (or <code>N</code> lines).
       </li>
       <li>
         <i>count</i>
@@ -203,6 +202,9 @@
       <li>
         <i>count</i>
         <code>e</code> Expand the focused node and all its siblings.
+      </li>
+      <li>
+        <code>Space</code> Toggle the collapsed state of the currently focused node.
       </li>
     </ul>
     <h3 id="scrolling">Scrolling</h3>

--- a/src/app.rs
+++ b/src/app.rs
@@ -122,11 +122,7 @@ impl App {
                             let lines = self.parse_input_buffer_as_number();
                             Some(Action::MoveUp(lines))
                         }
-                        Key::Down
-                        | Key::Char('j')
-                        | Key::Char(' ')
-                        | Key::Ctrl('n')
-                        | Key::Char('\n') => {
+                        Key::Down | Key::Char('j') | Key::Ctrl('n') | Key::Char('\n') => {
                             let lines = self.parse_input_buffer_as_number();
                             Some(Action::MoveDown(lines))
                         }
@@ -226,7 +222,7 @@ impl App {
                         Key::Char('H') => Some(Action::FocusParent),
                         Key::Char('c') => Some(Action::CollapseNodeAndSiblings),
                         Key::Char('e') => Some(Action::ExpandNodeAndSiblings),
-                        Key::Char('i') => Some(Action::ToggleCollapsed),
+                        Key::Char(' ') => Some(Action::ToggleCollapsed),
                         Key::Char('^') => Some(Action::FocusFirstSibling),
                         Key::Char('$') => Some(Action::FocusLastSibling),
                         Key::Char('g') | Key::Home => Some(Action::FocusTop),

--- a/src/jless.help
+++ b/src/jless.help
@@ -14,7 +14,7 @@
                                     [1mMOVING[0m
 
   j  DownArrow  *  Move focus down one line (or [4mN[0m lines).
-  ^n Enter Space
+  ^n Enter
 
   k  UpArrow    *  Move focus up   one line (or [4mN[0m lines).
   ^p Backspace
@@ -48,6 +48,8 @@
 
   c            Collapse the focused node and all its siblings.
   e            Expand   the focused node and all its siblings.
+
+  Space        Toggle the collapsed state of the currently focused node.
 
                                     [1mSCROLLING[0m
 


### PR DESCRIPTION
This functionality was previously available via `i`, but was undocumented. `i` has been unmapped.

Addresses https://github.com/PaulJuliusMartinez/jless/issues/41.