### PR TITLE
Ignore single line comment

### DIFF
--- a/src/jsonparser.rs
+++ b/src/jsonparser.rs
@@ -128,6 +128,10 @@ impl<'a> JsonParser<'a> {
                     panic!("Should have just consumed whitespace");
                 }
 
+                JsonToken::Comment => {
+                    panic!("Should have just consumed comment");
+                }
+
                 JsonToken::Error => {
                     return Err("Parse error".to_string());
                 }

--- a/src/jsonparser.rs
+++ b/src/jsonparser.rs
@@ -500,4 +500,14 @@ mod tests {
         assert_eq!(rows[7].range, 46..51); // false
         assert_eq!(rows[8].range, 51..52); // ]
     }
+
+    #[test]
+    fn test_parsing_json_with_comments() {
+        let json = r#"// This is a JSON with comments file
+{
+    "a": 1 // This is a comment
+}"#.to_owned();
+        let json_object = parse(json);
+        assert!(json_object.is_ok());
+    }
 }

--- a/src/jsontokenizer.rs
+++ b/src/jsontokenizer.rs
@@ -35,6 +35,9 @@ pub enum JsonToken {
     #[regex("[ \t\r]+", logos::skip)]
     Whitespace,
 
+    #[regex("//[^\n]*\n?", logos::skip)]
+    Comment,
+
     #[error]
     Error,
 }


### PR DESCRIPTION
To address #76 , skip the single line comment in JSON file during the tokenisation. The comment will NOT be displayed in jless.