### PR TITLE
Return Non-Zero Error Code on App::new Error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
         Ok(jl) => jl,
         Err(err) => {
             eprintln!("{}", err);
-            return;
+            std::process::exit(1);
         }
     };
 


### PR DESCRIPTION
When App is created in main, it was possible that it would return and
error and still have an exit code of 0. This has now been changed to 1
to represent the thrown error.

Solves #71 