### PR TITLE
[clippy] Fix unnecessary cast in screenwritter.rs.

### DIFF
--- a/src/screenwriter.rs
+++ b/src/screenwriter.rs
@@ -371,7 +371,7 @@ impl ScreenWriter {
             TruncatedStrView::init_start(filename, space_available_for_filename);
 
         if truncated_filename.any_contents_visible() {
-            let filename_width = truncated_filename.used_space().unwrap() as isize;
+            let filename_width = truncated_filename.used_space().unwrap();
             space_available_for_base -= filename_width - SPACE_BETWEEN_PATH_AND_FILENAME;
         }
 
@@ -409,7 +409,7 @@ impl ScreenWriter {
         }
 
         if truncated_filename.any_contents_visible() {
-            let filename_width = truncated_filename.used_space().unwrap() as isize;
+            let filename_width = truncated_filename.used_space().unwrap();
 
             self.terminal
                 .position_cursor(self.dimensions.width - (filename_width as u16) + 1, row)?;


### PR DESCRIPTION
Hello, just two small clippy fix:

```
:warning: casting to the same type is unnecessary (`isize` -> `isize`)
   --> src/screenwriter.rs:374:34
    |
374 |             let filename_width = truncated_filename.used_space().unwrap() as isize;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `truncated_filename.used_space().unwrap()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: casting to the same type is unnecessary (`isize` -> `isize`)
   --> src/screenwriter.rs:412:34
    |
412 |             let filename_width = truncated_filename.used_space().unwrap() as isize;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `truncated_filename.used_space().unwrap()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
```