### PR TITLE
Bump clap to version 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,32 +66,39 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "clap_lex",
+ "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -193,12 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,16 +212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -408,13 +399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -442,11 +436,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -619,10 +613,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.14.2"
+name = "unicode-ident"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 termion = "1.5.6"
 signal-hook = "0.3.8"
 libc = "0.2"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive"] }
 isatty = "0.1"
 libc-stdhandle = "0.1.0"
 yaml-rust = "0.4"

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 
-use clap::ArgEnum;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 use crate::viewer::Mode;
 
-#[derive(PartialEq, Eq, Copy, Clone, Debug, ArgEnum)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, ValueEnum)]
 pub enum DataFormat {
     Json,
     Yaml,
@@ -13,37 +12,46 @@ pub enum DataFormat {
 
 /// A pager for JSON (or YAML) data
 #[derive(Debug, Parser)]
-#[clap(name = "jless", version)]
+#[command(name = "jless", version)]
 pub struct Opt {
-    /// Input file. jless will read from stdin if no input file is
-    /// provided, or '-' is specified. If a filename is provided, jless
+    /// Input file.
+    ///
+    /// jless will read from stdin if no input file is
+    /// provided, or '-' is specified.
+    ///
+    /// If a filename is provided, jless
     /// will check the extension to determine what the input format is,
     /// and by default will assume JSON. Can specify input format
     /// explicitly using --json or --yaml.
-    #[clap(parse(from_os_str))]
     pub input: Option<PathBuf>,
 
-    /// Initial viewing mode. In line mode (--mode line), opening
+    /// Initial viewing mode.
+    ///
+    /// In line mode (--mode line), opening
     /// and closing curly and square brackets are shown and all
-    /// Object keys are quoted. In data mode (--mode data; the default),
+    /// Object keys are quoted.
+    ///
+    /// In data mode (--mode data; the default),
     /// closing braces, commas, and quotes around Object keys are elided.
     /// The active mode can be toggled by pressing 'm'.
-    #[clap(short, long, arg_enum, hide_possible_values = true, default_value_t = Mode::Data)]
+    #[arg(short, long, value_enum, hide_possible_values = true, default_value_t = Mode::Data)]
     pub mode: Mode,
 
     /// Number of lines to maintain as padding between the currently
-    /// focused row and the top or bottom of the screen. Setting this to
+    /// focused row and the top or bottom of the screen.
+    ///
+    /// Setting this to
     /// a large value will keep the focused in the middle of the screen
     /// (except at the start or end of a file).
-    #[clap(long = "scrolloff", default_value_t = 3)]
+    #[arg(long = "scrolloff", default_value_t = 3)]
     pub scrolloff: u16,
 
     /// Parse input as JSON, regardless of file extension.
-    #[clap(long = "json", group = "data-format", display_order = 1000)]
+    #[arg(long = "json", group = "data-format", display_order = 1000)]
     pub json: bool,
 
     /// Parse input as YAML, regardless of file extension.
-    #[clap(long = "yaml", group = "data-format", display_order = 1000)]
+    #[arg(long = "yaml", group = "data-format", display_order = 1000)]
     pub yaml: bool,
 }
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1,9 +1,9 @@
-use clap::ArgEnum;
+use clap::ValueEnum;
 
 use crate::flatjson::{FlatJson, Index, OptionIndex};
 use crate::types::TTYDimensions;
 
-#[derive(PartialEq, Eq, Copy, Clone, Debug, ArgEnum)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, ValueEnum)]
 pub enum Mode {
     Line,
     Data,


### PR DESCRIPTION
I'm back 😊

Clap 4 drops the indexmap dependency, which is presumably good for the compile time.

I also reformatted the longer help descriptions so they are cut off in short help mode `jless -h`, while also are printed in a more redable form for `jless --help`