### PR TITLE
Make clipboard support optional, with shell command escape hatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,3 @@ indoc = "1.0"
 [features]
 default = ["clipboard"]
 clipboard = ["dep:clipboard"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ clap = { version = "4.0", features = ["derive"] }
 isatty = "0.1"
 libc-stdhandle = "0.1.0"
 yaml-rust = "0.4"
-clipboard = "0.5"
+clipboard = { version = "0.5", optional = true }
 
 [dev-dependencies]
 indoc = "1.0"
+
+[features]
+default = ["clipboard"]
+clipboard = ["dep:clipboard"]
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,9 @@
+#[cfg(feature = "clipboard")]
 use std::error::Error;
 use std::io;
 use std::io::Write;
 
+#[cfg(feature = "clipboard")]
 use clipboard::{ClipboardContext, ClipboardProvider};
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
@@ -30,6 +32,7 @@ pub struct App {
     input_filename: String,
     search_state: SearchState,
     message: Option<(String, MessageSeverity)>,
+    #[cfg(feature = "clipboard")]
     clipboard_context: Result<ClipboardContext, Box<dyn Error>>,
 }
 
@@ -124,6 +127,7 @@ impl App {
             input_filename,
             search_state: SearchState::empty(),
             message: None,
+            #[cfg(feature = "clipboard")]
             clipboard_context: ClipboardProvider::new(),
         })
     }
@@ -220,6 +224,7 @@ impl App {
                     None
                 }
                 // y commands:
+                #[cfg(feature = "clipboard")]
                 event if self.input_state == InputState::PendingYCommand => {
                     let content_target = match event {
                         KeyEvent(Key::Char('y')) => Some(ContentTarget::PrettyPrintedValue),
@@ -282,6 +287,7 @@ impl App {
                     self.buffer_input(b'p');
                     None
                 }
+                #[cfg(feature = "clipboard")]
                 KeyEvent(Key::Char('y')) => {
                     match &self.clipboard_context {
                         Ok(_) => {
@@ -811,6 +817,7 @@ impl App {
         Ok(data)
     }
 
+    #[cfg(feature = "clipboard")]
     fn copy_content(&mut self, content_target: ContentTarget) {
         match self.get_content_target_data(content_target) {
             Ok(content) => {

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -1,0 +1,58 @@
+use std::fmt;
+use std::io::{self, Write};
+use std::process::{Command, ExitStatus, Stdio};
+
+#[cfg(feature = "clipboard")]
+use clipboard as sys_clipboard;
+
+#[derive(Debug)]
+pub enum ClipProvider {
+    CommandClipboard(String),
+    #[cfg(feature = "clipboard")]
+    SystemClipboard(sys_clipboard::ClipboardContext),
+}
+
+#[derive(Debug)]
+pub struct ClipError(pub String);
+impl fmt::Display for ClipError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl ClipProvider {
+    pub fn copy(&mut self, content: String) -> Result<(), ClipError> {
+        match self {
+            Self::CommandClipboard(shell_command) => {
+                let status = send_content_to_shell_command(content, shell_command)
+                    .map_err(|err| ClipError(err.to_string()))?;
+                match status.code() {
+                    Some(code) if !status.success() => {
+                        Err(ClipError(std::format!("Command failed with status code {}", code)))
+                    },
+                    Some(_) => Ok(()),
+                    None => Err(ClipError("Command terminated by signal".to_string())),
+                }
+            },
+
+            #[cfg(feature = "clipboard")]
+            Self::SystemClipboard(context) => {
+                context.set_contents(content)
+                    .map_err(|err| ClipError(err.to_string()))
+            },
+        }
+    }
+}
+
+fn send_content_to_shell_command(content: String, shell_command: &str) -> io::Result<ExitStatus> {
+    let mut child = Command::new("sh")
+        .args(&["-c", shell_command])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("Failed to grab stdin");
+    stdin.write_all(content.as_bytes())?;
+    drop(stdin);
+    child.wait()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ use std::io;
 use std::io::Read;
 use std::path::PathBuf;
 
+#[cfg(feature = "clipboard")]
+use clipboard as sys_clipboard;
+
 use clap::Parser;
 use termion::cursor::HideCursor;
 use termion::input::MouseTerminal;
@@ -19,6 +22,7 @@ use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 
 mod app;
+mod clip;
 mod flatjson;
 mod highlighting;
 mod input;
@@ -37,6 +41,7 @@ mod yamlparser;
 
 use app::App;
 use options::{DataFormat, Opt};
+use clip::{ClipProvider, ClipError};
 
 fn main() {
     let opt = Opt::parse();
@@ -67,7 +72,21 @@ fn main() {
     ))) as Box<dyn std::io::Write>;
     let raw_stdout = stdout.into_raw_mode().unwrap();
 
-    let mut app = match App::new(&opt, input_string, data_format, input_filename, raw_stdout) {
+    let clipboard_provider = match opt.clipboard_command {
+        Some(ref command) => {
+            Ok(ClipProvider::CommandClipboard(command.to_string()))
+        },
+        None => default_clip_provider(),
+    };
+
+    let mut app = match App::new(
+        &opt,
+        input_string,
+        data_format,
+        input_filename,
+        raw_stdout,
+        clipboard_provider,
+    ) {
         Ok(jl) => jl,
         Err(err) => {
             eprintln!("{err}");
@@ -76,6 +95,19 @@ fn main() {
     };
 
     app.run(Box::new(input::get_input()));
+}
+
+#[cfg(feature = "clipboard")]
+fn default_clip_provider() -> Result<ClipProvider, ClipError> {
+    match sys_clipboard::ClipboardProvider::new() {
+        Ok(clip) => Ok(ClipProvider::SystemClipboard(clip)),
+        Err(err) => Err(ClipError(err.to_string())),
+    }
+}
+
+#[cfg(not(feature = "clipboard"))]
+fn default_clip_provider() -> Result<ClipProvider, ClipError> {
+    Err(ClipError("No clipboard support, use --clipboard-cmd to set one".to_string()))
 }
 
 fn print_pretty_printed_input(input: String, data_format: DataFormat) {

--- a/src/options.rs
+++ b/src/options.rs
@@ -71,6 +71,11 @@ pub struct Opt {
     #[arg(long = "scrolloff", default_value_t = 3)]
     pub scrolloff: u16,
 
+    /// Shell command to run for copy actions instead of the default clipboard.
+    /// The copy content will be sent into the command's stdin.
+    #[clap(long = "clipboard-cmd")]
+    pub clipboard_command: Option<String>,
+
     /// Parse input as JSON, regardless of file extension.
     #[arg(long = "json", group = "data-format", display_order = 1000)]
     pub json: bool,


### PR DESCRIPTION
Supersedes #110 
Closes #84 
Closes #119 

This PR uses PR #110 to move the clipboard detection to a crate feature so it can be fully disabled, but it doesn't completely remove the copy actions.
Can be built using: `cargo build --no-default-features`

This PR also adds a command line option `--clipboard-cmd CMD` to be able to set an arbitrary shell command to use for copy actions as I requested in #119.

---
I tested this with the following commands:
```sh
$ ./target/debug/jless --clipboard-cmd 'cat > /tmp/clipboard' /path/to/a/file.json
```
In this case copy actions will send the copy target as input to `cat > /tmp/clipboard`.

And:
```sh
$ ./target/debug/jless /path/to/a/file.json
```
In this case copy actions will be disabled, with the error message:
`Unable to access clipboard: No clipboard support, use --clipboard-cmd to set one`