### PR TITLE
Moved cargo install description into the Installation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can install `jless` using various package managers:
 | [Void Linux](https://github.com/void-linux/void-packages/tree/master/srcpkgs/jless) | `sudo xbps-install jless` |
 | [NetBSD](https://pkgsrc.se/textproc/jless/)                | `pkgin install jless`     |
 | [FreeBSD](https://freshports.org/textproc/jless/)          | `pkg install jless`       |
-| Any OS (Requires [Rust toolchain](https://www.rust-lang.org/tools/install))          | `cargo install jless`       |
+| From source (Requires [Rust toolchain](https://www.rust-lang.org/tools/install))       | `cargo install jless`       |
 
 The [releases](https://github.com/PaulJuliusMartinez/jless/releases)
 page also contains links to binaries for various architectures.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ You can install `jless` using various package managers:
 | [Void Linux](https://github.com/void-linux/void-packages/tree/master/srcpkgs/jless) | `sudo xbps-install jless` |
 | [NetBSD](https://pkgsrc.se/textproc/jless/)                | `pkgin install jless`     |
 | [FreeBSD](https://freshports.org/textproc/jless/)          | `pkg install jless`       |
-
-If you have a Rust toolchain installed, you can install `jless` from
-source by running `cargo install jless`.
+| Any OS (Requires [Rust toolchain](https://www.rust-lang.org/tools/install))          | `cargo install jless`       |
 
 The [releases](https://github.com/PaulJuliusMartinez/jless/releases)
 page also contains links to binaries for various architectures.


### PR DESCRIPTION
The cargo install command was in plain text, which makes it a bit hard to spot at first glance. This is why I moved it into the table under "Any OS". Addresses #120