### PR TITLE
use a channel for stdin and SIGWINCH

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2,15 +2,15 @@ use signal_hook::consts::SIGWINCH;
 use signal_hook::low_level::pipe;
 use termion::event::{parse_event, Event, Key, MouseEvent};
 
-use std::io;
+use std::{io, thread};
 use std::io::{stdin, Read, Stdin};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
 
 const POLL_INFINITE_TIMEOUT: i32 = -1;
-const SIGWINCH_PIPE_INDEX: usize = 0;
 const BUFFER_SIZE: usize = 1024;
-
 const ESCAPE: u8 = 0o33;
 
 pub fn remap_dev_tty_to_stdin() {
@@ -63,7 +63,6 @@ struct BufferedInput<const N: usize> {
     buffer: [u8; N],
     buffer_size: usize,
     buffer_index: usize,
-    might_have_more_data: bool,
 }
 
 impl<const N: usize> BufferedInput<N> {
@@ -73,7 +72,6 @@ impl<const N: usize> BufferedInput<N> {
             buffer: [0; N],
             buffer_size: 0,
             buffer_index: 0,
-            might_have_more_data: false,
         }
     }
 
@@ -97,11 +95,6 @@ impl<const N: usize> BufferedInput<N> {
 
         self.buffer_size = 0;
         self.buffer_index = 0;
-        self.might_have_more_data = false;
-    }
-
-    fn might_have_buffered_data(&self) -> bool {
-        self.might_have_more_data || self.has_buffered_data()
     }
 
     fn has_buffered_data(&self) -> bool {
@@ -110,9 +103,6 @@ impl<const N: usize> BufferedInput<N> {
 
     fn take_pure_escape(&mut self) -> bool {
         if self.buffer_index == 0 && self.buffer_size == 1 && self.buffer[0] == ESCAPE {
-            // This will set self.might_have_more_data = true, which is fine,
-            // because that only gets set to true when buffer_size == N, but
-            // we just checked that it is 1 and not N.
             self.clear();
             return true;
         }
@@ -130,7 +120,6 @@ impl<const N: usize> BufferedInput<N> {
         match read_and_retry_on_interrupt(&mut self.input, &mut self.buffer) {
             Ok(bytes_read) => {
                 self.buffer_size = bytes_read;
-                self.might_have_more_data = bytes_read == N;
                 None
             }
             Err(err) => Some(err),
@@ -151,49 +140,91 @@ impl<const N: usize> Iterator for BufferedInput<N> {
 }
 
 struct TuiInput {
-    poll_fds: [libc::pollfd; 2],
-    sigwinch_pipe: UnixStream,
-    buffered_input: BufferedInput<BUFFER_SIZE>,
+    events_channel_receiver: Receiver<io::Result<TuiEvent>>,
 }
 
 impl TuiInput {
     fn new(input: Stdin, sigwinch_pipe: UnixStream) -> TuiInput {
-        let sigwinch_fd = sigwinch_pipe.as_raw_fd();
-        let stdin_fd = input.as_raw_fd();
+        let (send, recv) = mpsc::channel();
+        Self::spawn_thread_buffered_input(input, &send);
+        Self::spawn_thread_sigwinch_handler(sigwinch_pipe, &send);
 
-        let poll_fds: [libc::pollfd; 2] = [
+        TuiInput {
+            events_channel_receiver: recv,
+        }
+    }
+
+    fn spawn_thread_buffered_input(input: Stdin, send: &Sender<io::Result<TuiEvent>>) {
+        let send = send.clone();
+        let mut buffered_input = BufferedInput::<BUFFER_SIZE>::new(input);
+        thread::spawn(move || {
+            loop {
+                match Self::get_event_from_buffered_input(&mut buffered_input) {
+                    None => break,
+                    Some(result) => send.send(result).unwrap(),
+                }
+            }
+        });
+    }
+
+    fn spawn_thread_sigwinch_handler(mut signal_pipe: UnixStream, send: &Sender<io::Result<TuiEvent>>) {
+        let send = send.clone();
+        let mut poll_fd_arr: [libc::pollfd; 1] = [
             libc::pollfd {
-                fd: sigwinch_fd,
-                events: libc::POLLIN,
-                revents: 0,
-            },
-            libc::pollfd {
-                fd: stdin_fd,
+                fd: signal_pipe.as_raw_fd(),
                 events: libc::POLLIN,
                 revents: 0,
             },
         ];
+        thread::spawn(move || {
+            loop {
+                let result = match await_next_signal(&mut poll_fd_arr) {
+                    Ok(_) => {
+                        // Drain the stream. Just make this is big enough to absorb a bunch of
+                        // unacknowledged SIGWINCHes.
+                        if poll_fd_arr[0].revents & libc::POLLIN != 0 {
+                            let mut buf = [0; 32];
+                            let _ = signal_pipe.read(&mut buf);
+                        }
+                        Ok(TuiEvent::WinChEvent)
+                    }
+                    Err(err) => Err(err),
+                };
+                send.send(result).unwrap();
+            }
+        });
+    }
 
-        TuiInput {
-            poll_fds,
-            sigwinch_pipe,
-            buffered_input: BufferedInput::new(input),
+    fn await_next_signal<const N: usize>(signal_pipes: &mut [libc::pollfd; N]) -> io::Result<()> {
+        loop {
+            match unsafe { libc::poll(signal_pipes.as_mut_ptr(), N as libc::nfds_t, POLL_INFINITE_TIMEOUT) } {
+                -1 => {
+                    let err = io::Error::last_os_error();
+                    if err.kind() != io::ErrorKind::Interrupted {
+                        return Err(err);
+                    }
+                    // Try poll again.
+                }
+                _ => {
+                    return Ok(());
+                }
+            };
         }
     }
 
-    fn get_event_from_buffered_input(&mut self) -> Option<io::Result<TuiEvent>> {
-        if !self.buffered_input.has_buffered_data() {
-            if let Some(err) = self.buffered_input.read_more_if_needed() {
+    fn get_event_from_buffered_input<const N: usize>(input: &mut BufferedInput<N>) -> Option<io::Result<TuiEvent>> {
+        if !input.has_buffered_data() {
+            if let Some(err) = input.read_more_if_needed() {
                 return Some(Err(err));
             }
         }
 
-        if self.buffered_input.take_pure_escape() {
+        if input.take_pure_escape() {
             return Some(Ok(TuiEvent::KeyEvent(Key::Esc)));
         }
 
-        match self.buffered_input.next() {
-            Some(Ok(byte)) => match parse_event(byte, &mut self.buffered_input) {
+        match input.next() {
+            Some(Ok(byte)) => match parse_event(byte, input) {
                 Ok(Event::Key(k)) => Some(Ok(TuiEvent::KeyEvent(k))),
                 Ok(Event::Mouse(m)) => Some(Ok(TuiEvent::MouseEvent(m))),
                 Ok(Event::Unsupported(bytes)) => Some(Ok(TuiEvent::Unknown(bytes))),
@@ -203,47 +234,14 @@ impl TuiInput {
             None => None,
         }
     }
+
 }
 
 impl Iterator for TuiInput {
     type Item = io::Result<TuiEvent>;
 
     fn next(&mut self) -> Option<io::Result<TuiEvent>> {
-        if self.buffered_input.might_have_buffered_data() {
-            return self.get_event_from_buffered_input();
-        }
-
-        let poll_res: Option<io::Error>;
-
-        loop {
-            match unsafe { libc::poll(self.poll_fds.as_mut_ptr(), 2, POLL_INFINITE_TIMEOUT) } {
-                -1 => {
-                    let err = io::Error::last_os_error();
-                    if err.kind() != io::ErrorKind::Interrupted {
-                        poll_res = Some(err);
-                        break;
-                    }
-                    // Try poll again.
-                }
-                _ => {
-                    poll_res = None;
-                    break;
-                }
-            };
-        }
-
-        if let Some(poll_err) = poll_res {
-            return Some(Err(poll_err));
-        }
-
-        if self.poll_fds[SIGWINCH_PIPE_INDEX].revents & libc::POLLIN != 0 {
-            // Just make this big enough to absorb a bunch of unacknowledged SIGWINCHes.
-            let mut buf = [0; 32];
-            let _ = self.sigwinch_pipe.read(&mut buf);
-            return Some(Ok(TuiEvent::WinChEvent));
-        }
-
-        self.get_event_from_buffered_input()
+        self.events_channel_receiver.recv().ok()
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -178,7 +178,7 @@ impl TuiInput {
         ];
         thread::spawn(move || {
             loop {
-                let result = match await_next_signal(&mut poll_fd_arr) {
+                let result = match Self::await_next_signal(&mut poll_fd_arr) {
                     Ok(_) => {
                         // Drain the stream. Just make this is big enough to absorb a bunch of
                         // unacknowledged SIGWINCHes.


### PR DESCRIPTION
> **note**
> I have only tested this on macOS. If someone can test it on linux for me, I'd appreciate it!

By using a channel, we can remove the need for calling `libc::poll` on the stdin pipe. This doesn't work on the Mac: when we redirect tty to stdin, it breaks the original stdin pipe (fd 0), such that `libc::poll` on it returns instantly, with an revents of POLLNVAL (invalid pipe). Also, macOS [doesn't support `libc::poll` on devices][1], so we can't poll tty directly.

Instead, we spawn two threads: one just reads stdin forever, and the other uses the socket to listen for SIGWINCH events as before (using `libc::poll`). These both write to a channel, and the `TuiInput` simply reads from this channel.

There's no attempt to interrupt or join the two threads: they both just go on as long as the program does. I can add a "stop listening" signal if you like, but that felt like unnecessary complication given the current flow.

This fixes #2.

[1]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/poll.2.html