### PR TITLE
make clipboard functionality optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ edition = "2018"
 rust-version = "1.67"
 
 [features]
-default = []
+default = ["clipboard"]
 sexp = []
+clipboard = ["dep:clipboard"]
 
 [dependencies]
 logos = "0.12.0"
@@ -30,7 +31,8 @@ clap = { version = "4.0", features = ["derive"] }
 isatty = "0.1"
 libc-stdhandle = "0.1.0"
 yaml-rust = "0.4"
-clipboard = "0.5"
+
+clipboard = { version = "0.5", optional = true }
 
 [dev-dependencies]
 indoc = "1.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,9 @@ use std::fs::File;
 use std::io;
 use std::io::Write;
 
+#[cfg(feature = "clipboard")]
 use clipboard::{ClipboardContext, ClipboardProvider};
+
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use termion::event::Key;
@@ -31,6 +33,8 @@ pub struct App {
     input_filename: String,
     search_state: SearchState,
     message: Option<(String, MessageSeverity)>,
+
+    #[cfg(feature = "clipboard")]
     clipboard_context: Result<ClipboardContext, Box<dyn Error>>,
 }
 
@@ -137,6 +141,8 @@ impl App {
             input_filename,
             search_state: SearchState::empty(),
             message: None,
+
+            #[cfg(feature = "clipboard")]
             clipboard_context: ClipboardProvider::new(),
         })
     }
@@ -254,6 +260,8 @@ impl App {
 
                     None
                 }
+
+                #[cfg(feature = "clipboard")]
                 // y commands:
                 event if self.input_state == InputState::PendingYCommand => {
                     let content_target = match event {
@@ -317,7 +325,9 @@ impl App {
                     self.buffer_input(b'p');
                     None
                 }
+
                 KeyEvent(Key::Char('y')) => {
+                    #[cfg(feature = "clipboard")]
                     match &self.clipboard_context {
                         Ok(_) => {
                             self.input_state = InputState::PendingYCommand;
@@ -884,6 +894,7 @@ impl App {
         Ok(data)
     }
 
+    #[cfg(feature = "clipboard")]
     fn copy_content(&mut self, content_target: ContentTarget) {
         match self.get_content_target_data(content_target) {
             Ok(content) => {


### PR DESCRIPTION
I use jless on the server, where x11 is not installed. It would be nice if jless could be used without bringing in the x11 dependency.