### PR TITLE
feat: jless default opts env

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use app::App;
 use options::{DataFormat, Opt};
 
 fn main() {
-    let opt = Opt::parse();
+    let opt = Opt::parse_with_default();
 
     let (input_string, input_filename) = match get_input_and_filename(&opt) {
         Ok(input_and_filename) => input_and_filename,

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,4 +90,23 @@ impl Opt {
             None
         }
     }
+
+    fn default_opts_iter() -> impl Iterator<Item = String> {
+        std::env::var("JLESS_DEFAULT_OPTS")
+            .unwrap_or("".to_string())
+            .split(" ")
+            .filter(|v| v.trim_ascii().len() != 0)
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    pub fn parse_with_default() -> Self {
+        Self::parse_from(
+            std::env::args()
+                .take(1)
+                .chain(Self::default_opts_iter())
+                .chain(std::env::args().skip(1)),
+        )
+    }
 }


### PR DESCRIPTION
## Problem

There is no way to set preferred default config flags. 

## Solution

I propose to add a new env variable `JLESS_DEFAULT_OPTS` inspired by `FZF_DEFAULT_OPTS` which doesn't require to choose a new config file format (json/yaml/toml) and allows configuration just as you would type the config in your shell.

For example:

```sh
export JLESS_DEFAULT_OPTS="-r"
# now jless will launch with relative numbers by default
jless
```

### Notes

Current implementation does not handle config properties with spaces in them
`JLESS_DEFAULT_OPTS="--file \"foo bar\""` wouldn't work


closes #174 

