### PR TITLE
Add `-r` shortcut to toggle absolute/relative line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ main
 ====
 
 Improvements:
+- [Issue #134]: Add a single-key shortcut `r` to toggle between
+  absolute-only and relative-only line numbers at runtime. The numeric
+  count buffer is cleared on toggle for consistency with other
+  single-key commands. Help text updated accordingly.
 - [Issue #143]: `ctrl-z` will now send jless to the background
 - `:w[rite] <file>` and `:w[rite]! <file>` can be used to write the
   current input to a file

--- a/src/app.rs
+++ b/src/app.rs
@@ -463,6 +463,13 @@ impl App {
                         Key::End => Some(Action::FocusBottom),
                         Key::Char('%') => Some(Action::FocusMatchingPair),
                         Key::Char('m') => Some(Action::ToggleMode),
+                        Key::Char('r') => {
+                            crate::screenwriter::toggle_line_number_mode(
+                                &mut self.screen_writer.show_line_numbers,
+                                &mut self.screen_writer.show_relative_line_numbers,
+                            );
+                            None
+                        }
                         Key::Char('<') => {
                             self.screen_writer
                                 .decrease_indentation_level(self.viewer.flatjson.2 as u16);

--- a/src/jless.help
+++ b/src/jless.help
@@ -235,6 +235,9 @@
       is from the currently focused line. This makes it easier to use the j
       and k commands with specified counts.
 
+      Press 'r' at any time to toggle between absolute-only and
+      relative-only line numbers.
+
       The appearance of line numbers can be configured via command line flags:
 
   -n, --line-numbers              Show absolute line numbers.

--- a/src/screenwriter.rs
+++ b/src/screenwriter.rs
@@ -570,3 +570,39 @@ impl ScreenWriter {
         }
     }
 }
+
+// Toggle between absolute-only and relative-only line numbers.
+// If both flags are the same (both true or both false), default to absolute-only.
+pub(crate) fn toggle_line_number_mode(
+    show_absolute_line_numbers: &mut bool,
+    show_relative_line_numbers: &mut bool,
+) {
+    if *show_absolute_line_numbers == *show_relative_line_numbers {
+        // If both are the same (both true or both false), normalize to absolute-only.
+        *show_absolute_line_numbers = true;
+        *show_relative_line_numbers = false;
+    } else {
+        // Otherwise, flip to the other exclusive mode.
+        *show_absolute_line_numbers = !*show_absolute_line_numbers;
+        *show_relative_line_numbers = !*show_relative_line_numbers;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::toggle_line_number_mode;
+
+    #[test]
+    fn toggle_line_number_mode_cases() {
+        for (start_absolute, start_relative, expected_absolute, expected_relative) in vec![
+            (true, false, false, true),
+            (false, true, true, false),
+            (true, true, true, false),
+            (false, false, true, false),
+        ] {
+            let (mut absolute, mut relative) = (start_absolute, start_relative);
+            toggle_line_number_mode(&mut absolute, &mut relative);
+            assert_eq!((absolute, relative), (expected_absolute, expected_relative));
+        }
+    }
+}


### PR DESCRIPTION
 Hello, this is a cool project! Would like to make this change

---

Add `-r` shortcut to toggle absolute/relative line numbers

To close https://github.com/PaulJuliusMartinez/jless/issues/134

---

```
>  cargo test
warning: method `clear_screen` is never used
  --> src/terminal.rs:57:8
   |
56 | pub trait Terminal: Write {
   |           -------- method in this trait
57 |     fn clear_screen(&mut self) -> Result;
   |        ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `jless` (bin "jless" test) generated 1 warning
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests src/main.rs (target/debug/deps/jless-5cfd06cee43ef823)

...

test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```
➜  cargo build
warning: methods `clear_screen`, `output`, and `clear_output` are never used
  --> src/terminal.rs:57:8
   |
56 | pub trait Terminal: Write {
   |           -------- methods in this trait
57 |     fn clear_screen(&mut self) -> Result;
   |        ^^^^^^^^^^^^
...
72 |     fn output(&self) -> &str;
   |        ^^^^^^
...
75 |     fn clear_output(&mut self);
   |        ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `jless` (bin "jless") generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
```